### PR TITLE
use pkg-config for libbsd

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,37 @@
+# nsutils: namespace utilities
+# Copyright (C) 2022  Guilherme Janczak <guilherme.janczak@yandex.com>
+#
+# build-and-test.yml: Github Actions automated testing
+#
+# Cado is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.1
+      - name: install
+        run: |
+          sudo apt update
+          sudo apt upgrade gcc autoconf libbsd-dev libcap-dev
+      - name: setup
+        run: |
+          autoreconf -if
+          ./configure
+      - name: build
+        run: make
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,8 @@ bin_PROGRAMS = nshold nslist nsrelease netnsjoin
 
 nshold_SOURCES = nshold.c catargv.c prefix.c
 
-nshold_LDADD = -lbsd -lcap
+nshold_LDADD = @LIBBSD_LIBS@ -lcap
+nshold_CFLAGS = @LIBBSD_CFLAGS@ $(AM_CFLAGS)
 
 nslist_SOURCES = nslist.c catargv.c memogetusername.c prefix.c printflen.c
 
@@ -13,7 +14,7 @@ netnsjoin_SOURCES = netnsjoin.c nssearch.c catargv.c prefix.c
 netnsjoin_LDADD = -lcap
 
 man_MANS = netnsjoin.1 nshold.1 nslist.1 nsrelease.1
- 
+
 install-exec-hook:
 	ln -sf nshold $(DESTDIR)$(bindir)/cgroupnshold
 	ln -sf nslist $(DESTDIR)$(bindir)/cgroupnslist

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-#NSUTILS: Linux namespace utilities
+# NSUTILS - linux namespace utilities
+The nsutils suite includes a number of utilities to list, tag, and join
+namespaces.
 
-Nsutils suite includes a number of utilities to list, add/remove tag, and join namespaces.
+## Build instructions
+Install the following dependencies:
+- [autoconf](https://www.gnu.org/software/autoconf/autoconf.html) (build time only)
+- [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
+- [libbsd](https://libbsd.freedesktop.org/wiki/)
+- [libcap](https://sites.google.com/site/fullycapable/)
 
-INSTALL:
-
-get the source code, from the root of the source tree run:
-```
+Get the source code, and from the root of the source tree run:
+```sh
 $ autoreconf -if
 $ ./configure
 $ make
@@ -14,11 +19,11 @@ $ sudo make install
 
 **nslist**, **nshold** and **nsrelease** restrict their action to one type
 of namespaces using one of the following prefixes:
-**cgroup**, **ipc**, **mnt**, **net**, **pid**, **user**, **uts**.  
+**cgroup**, **ipc**, **mnt**, **net**, **pid**, **user**, **uts**.
 i.e. use **nslist** to list namespaces of any kind, **netnslist** to list
 network namespaces only.
 
-The suite includes a set of man pages providing a complete description of the tools and a detailed commented 
+The suite includes a set of man pages providing a complete description of the tools and a detailed commented
 list of all the options.
 
 This page gives just some examples of common usage cases to show what
@@ -101,7 +106,7 @@ $ netnslist -T -R "bash"
 ```
 
 - list the namespaces of a specific user (for root. All the commands above
-can be restricted to the processes of a specific user by the `-U` option) 
+can be restricted to the processes of a specific user by the `-U` option)
 ```
 # nslist -U myuser -ss
 cgroup:[4026531835]
@@ -176,7 +181,7 @@ net:[4026532883]
 A namespace survives until there is at least a process running in it (or if
 it has been *mounted*, see mount(2))
 
-**nshold** creates a namespace *placeholder*: 
+**nshold** creates a namespace *placeholder*:
 an idle process whose cmdline is the namespace id
 (so it can be easily found in the output of ps(1)).
 
@@ -254,7 +259,7 @@ net:[4026532883]
 ```
 
 ```
-$ nslist -T -r house 
+$ nslist -T -r house
           NAMESPACE      PID CMDLINE
    net:[4026532883]    10297 net:[4026532883] safenet
    net:[4026532883]    10348 net:[4026532883] house automation

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,9 @@ AC_CHECK_HEADERS([sys/capability.h],
 		[],
 		[AC_MSG_ERROR([missing libcap header])])
 
+PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay],,
+		 [AC_MSG_ERROR([libbsd not found])])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_UID_T
 AC_TYPE_PID_T

--- a/nshold.c
+++ b/nshold.c
@@ -1,22 +1,22 @@
-/* 
+/*
  * nsutils: namespace utilities
  * Copyright (C) 2016  Renzo Davoli, University of Bologna
- * 
+ *
  * nshold: keep-alive and give a name tag to a namespace
  *
  * Cado is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
- * along with this program; If not, see <http://www.gnu.org/licenses/>. 
- *  
+ * along with this program; If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <sys/capability.h>
-#include <bsd/unistd.h>
+#include <unistd.h>
 
 #include <catargv.h>
 #include <prefix.h>
@@ -86,7 +86,7 @@ int main(int argc, char **argv, char **envp)
 	else
 		asprintf(&prefix, "%*.*s", prefixlen, prefixlen, progname);
 
-	if (dashdash < argc) 
+	if (dashdash < argc)
 		tag = catargv(argv+(dashdash + 1));
 	else if (argc == 2)
 		tag = argv[1];
@@ -94,9 +94,9 @@ int main(int argc, char **argv, char **envp)
 		usage_and_exit(progname, prefix);
 
 	clear_all_caps();
-	
+
 	asprintf(&nspath, "%s%*.*s", NSPATH, prefixlen, prefixlen, basename(argv[0]));
-	if ((nsname = readlinkdup(nspath)) == NULL) 
+	if ((nsname = readlinkdup(nspath)) == NULL)
 		return 1;
 
 	setproctitle_init(argc, argv, envp);


### PR DESCRIPTION
Hi, I'm working on my own alternative to libbsd called [libobsd](https://github.com/guijan/libobsd) and using pkg-config in addition to libbsd's overlay mode makes it very easy to replace libbsd for me.
Currently, I'm trying to get my library into openwrt: https://github.com/openwrt/openwrt/pull/9714

This PR performs all the changes I think I need, I've also added automated build testing and touched up the README.